### PR TITLE
Update the usage on readme to use the right artifactId

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -14,7 +14,7 @@ You just need the following plugin declaration in your walkmod.xml:
 <!DOCTYPE walkmod PUBLIC "-//WALKMOD//DTD"  "http://www.walkmod.com/dtd/walkmod-1.0.dtd" >
 <walkmod>
   <plugins>
-    <plugin groupId="org.walkmod" artifactId="walkmod-imports-cleaner-plugin" version="2.0" />
+    <plugin groupId="org.walkmod" artifactId="walkmod-setter-getter-plugin" version="2.0" />
   </plugins>
   ....
 </walkmod>


### PR DESCRIPTION
The usage for this plugin was importing imports-cleaner artifact instead of its own artifact id.
